### PR TITLE
Consistent width and padding for separate dial code option

### DIFF
--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.css
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.css
@@ -40,6 +40,14 @@ li.country:hover {
 	padding-left: 6px;
 }
 
-.intl-tel-input.separate-dial-code .selected-flag .iti-arrow {
-    right: 4px;
+.intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-2 .selected-flag,
+.intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-3 .selected-flag,
+.intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-4 .selected-flag {
+	width: 93px;
+}
+
+.intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-2 input,
+.intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-3 input,
+.intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-4 input {
+	padding-left: 98px;
 }

--- a/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.css
+++ b/projects/ngx-intl-tel-input/src/lib/ngx-intl-tel-input.component.css
@@ -40,12 +40,15 @@ li.country:hover {
 	padding-left: 6px;
 }
 
+.intl-tel-input.separate-dial-code .selected-flag,
 .intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-2 .selected-flag,
 .intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-3 .selected-flag,
 .intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-4 .selected-flag {
 	width: 93px;
 }
 
+
+.intl-tel-input.separate-dial-code input,
 .intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-2 input,
 .intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-3 input,
 .intl-tel-input.separate-dial-code.allow-dropdown.iti-sdc-4 input {


### PR DESCRIPTION
I think this is a better approach for this issue, as it keeps everything in place and consistently spaced across different dial code lengths.

What do you think?